### PR TITLE
[feat],[fix] 이상형 월드컵 게임 기능 전면 수정

### DIFF
--- a/src/main/java/com/multi/cookies/entertainment/controller/IdealWorldCupController.java
+++ b/src/main/java/com/multi/cookies/entertainment/controller/IdealWorldCupController.java
@@ -2,7 +2,9 @@ package com.multi.cookies.entertainment.controller;
 
 import com.multi.cookies.entertainment.dao.IdealWorldCupDAO;
 import com.multi.cookies.entertainment.dto.IdealWorldCupDTO;
+import com.multi.cookies.entertainment.dto.InitialSnackListDTO;
 import com.multi.cookies.entertainment.dto.PageDTO;
+import com.multi.cookies.entertainment.service.IdealWorldCupService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -17,13 +20,16 @@ public class IdealWorldCupController {
 
     @Autowired
     IdealWorldCupDAO idealWorldCupDAO;
+    @Autowired
+    private IdealWorldCupService idealWorldCupService;
 
     @RequestMapping("/entertainment/idealWorldCupList")
-    public void list2(PageDTO pageDTO, Model model){
+    public void list2(PageDTO pageDTO, Model model) {
         pageDTO.setStartEnd(pageDTO.getPage());
         List<IdealWorldCupDTO> list = idealWorldCupDAO.list2(pageDTO);
         model.addAttribute("list", list);
     }
+
     @RequestMapping("/entertainment/idealWorldCupAll")
     public void all2(PageDTO pageDTO, Model model) {
         pageDTO.setStartEnd(pageDTO.getPage());
@@ -34,23 +40,22 @@ public class IdealWorldCupController {
         model.addAttribute("count", count);
         model.addAttribute("pages", pages);
     }
-    @RequestMapping("/entertainment/idealWorldCupGame")
-    public void list(Model model) {
-        List<String> list = idealWorldCupDAO.list();
-        model.addAttribute("list",list);
-        //System.out.println(list);
-    }
+
     @RequestMapping("/updateWinnerWins")
     @ResponseBody
-    public String updateWinnerWins(@RequestParam("winnerName") String winnerName) {
+    public String updateWinnerWins(@RequestParam("snack_id") int snack_id) {
         try {
-            // winnerName을 기반으로 DB 업데이트 수행
-            idealWorldCupDAO.updateWins(winnerName);
+            // snackId를 기반으로 DB 업데이트 수행
+            idealWorldCupDAO.updateWins(snack_id);
             return "Success"; // 성공 시 메시지 반환
         } catch (Exception e) {
             e.printStackTrace();
             return "Error"; // 실패 시 메시지 반환
         }
     }
-
+    @RequestMapping("/entertainment/idealWorldCupGame")
+    public void randomSnacks(@RequestParam("kang") int kang, Model model) {
+        List<InitialSnackListDTO> randomSnacks = idealWorldCupService.getRandomSnacks(kang);
+        model.addAttribute("randomSnacks", randomSnacks);
+    }
 }

--- a/src/main/java/com/multi/cookies/entertainment/dao/IdealWorldCupDAO.java
+++ b/src/main/java/com/multi/cookies/entertainment/dao/IdealWorldCupDAO.java
@@ -1,6 +1,7 @@
 package com.multi.cookies.entertainment.dao;
 
 import com.multi.cookies.entertainment.dto.IdealWorldCupDTO;
+import com.multi.cookies.entertainment.dto.InitialSnackListDTO;
 import com.multi.cookies.entertainment.dto.PageDTO;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,14 +23,10 @@ public class IdealWorldCupDAO {
     public int count() {
         return my.selectOne("worldCup.count");
     }
-    public List<String> list() {
-        return my.selectList("worldCup.list");
+    public void updateWins(int snack_id) {
+        my.update("worldCup.updateWinsForSnack", snack_id);
     }
-//    public IdealWorldCupDTO one(String ideal_snack_name) {
-//        return my.selectOne("worldCup.one", ideal_snack_name);
-//    }
-    public void updateWins(String winnerName) {
-        my.update("worldCup.updateWins", winnerName);
+    public List<InitialSnackListDTO> getRandomSnacks(int limit) {
+        return my.selectList("worldCup.getRandomSnacks", limit);
     }
-
 }

--- a/src/main/java/com/multi/cookies/entertainment/dto/IdealWorldCupDTO.java
+++ b/src/main/java/com/multi/cookies/entertainment/dto/IdealWorldCupDTO.java
@@ -1,13 +1,11 @@
 package com.multi.cookies.entertainment.dto;
 
-import java.util.Date;
-
 public class IdealWorldCupDTO {
     private int idealRanking;
-    private int ideal_snack_id;
-    private String ideal_snack_name;
-    private String ideal_snack_img;
-    private int ideal_snack_wins;
+    private int snack_id;
+    private String snack_name;
+    private String snack_img;
+    private int wins;
     public int getIdealRanking() {
         return idealRanking;
     }
@@ -16,46 +14,46 @@ public class IdealWorldCupDTO {
         this.idealRanking = idealRanking;
     }
 
-    public int getIdeal_snack_id() {
-        return ideal_snack_id;
+    public int getSnack_id() {
+        return snack_id;
     }
 
-    public void setIdeal_snack_id(int ideal_snack_id) {
-        this.ideal_snack_id = ideal_snack_id;
+    public void setSnack_id(int snack_id) {
+        this.snack_id = snack_id;
     }
 
-    public String getIdeal_snack_name() {
-        return ideal_snack_name;
+    public String getSnack_name() {
+        return snack_name;
     }
 
-    public void setIdeal_snack_name(String ideal_snack_name) {
-        this.ideal_snack_name = ideal_snack_name;
+    public void setSnack_name(String snack_name) {
+        this.snack_name = snack_name;
     }
 
-    public String getIdeal_snack_img() {
-        return ideal_snack_img;
+    public String getSnack_img() {
+        return snack_img;
     }
 
-    public void setIdeal_snack_img(String ideal_snack_img) {
-        this.ideal_snack_img = ideal_snack_img;
+    public void setSnack_img(String snack_img) {
+        this.snack_img = snack_img;
     }
 
-    public int getIdeal_snack_wins() {
-        return ideal_snack_wins;
+    public int getWins() {
+        return wins;
     }
 
-    public void setIdeal_snack_wins(int ideal_snack_wins) {
-        this.ideal_snack_wins = ideal_snack_wins;
+    public void setWins(int wins) {
+        this.wins = wins;
     }
 
     @Override
     public String toString() {
         return "IdealWorldCupDTO{" +
                 "idealRanking=" + idealRanking +
-                ", ideal_snack_id=" + ideal_snack_id +
-                ", ideal_snack_name='" + ideal_snack_name + '\'' +
-                ", ideal_snack_img='" + ideal_snack_img + '\'' +
-                ", ideal_snack_wins=" + ideal_snack_wins +
+                ", ideal_snack_id=" + snack_id +
+                ", ideal_snack_name='" + snack_name + '\'' +
+                ", ideal_snack_img='" + snack_img + '\'' +
+                ", ideal_snack_wins=" + wins +
                 '}';
     }
 }

--- a/src/main/java/com/multi/cookies/entertainment/dto/InitialSnackListDTO.java
+++ b/src/main/java/com/multi/cookies/entertainment/dto/InitialSnackListDTO.java
@@ -1,0 +1,40 @@
+package com.multi.cookies.entertainment.dto;
+
+public class InitialSnackListDTO {
+    private int snack_id;
+    private String snack_name;
+    private String snack_img;
+
+    public int getSnack_id() {
+        return snack_id;
+    }
+
+    public void setSnack_id(int snack_id) {
+        this.snack_id = snack_id;
+    }
+
+    public String getSnack_name() {
+        return snack_name;
+    }
+
+    public void setSnack_name(String snack_name) {
+        this.snack_name = snack_name;
+    }
+
+    public String getSnack_img() {
+        return snack_img;
+    }
+
+    public void setSnack_img(String snack_img) {
+        this.snack_img = snack_img;
+    }
+
+    @Override
+    public String toString() {
+        return "InitialSnackListDTO{" +
+                "snack_id=" + snack_id +
+                ", snack_name='" + snack_name + '\'' +
+                ", snack_img='" + snack_img + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/multi/cookies/entertainment/service/IdealWorldCupService.java
+++ b/src/main/java/com/multi/cookies/entertainment/service/IdealWorldCupService.java
@@ -1,6 +1,8 @@
+// IdealWorldCupService.java
 package com.multi.cookies.entertainment.service;
 
 import com.multi.cookies.entertainment.dto.IdealWorldCupDTO;
+import com.multi.cookies.entertainment.dto.InitialSnackListDTO;
 import com.multi.cookies.entertainment.dto.PageDTO;
 
 import java.util.List;
@@ -8,7 +10,8 @@ import java.util.List;
 public interface IdealWorldCupService {
     List<IdealWorldCupDTO> getAllSnacks(PageDTO pageDTO);
     List<IdealWorldCupDTO> getSnacksByRanking(PageDTO pageDTO);
-    List<String> getAllSnackNames();
-    void updateWins(String winnerName);
     int getSnackCount();
+    void updateWinnerWins(int snack_id);
+    public List<InitialSnackListDTO> getRandomSnacks(int limit);
+
 }

--- a/src/main/java/com/multi/cookies/entertainment/service/IdealWorldCupServiceImpl.java
+++ b/src/main/java/com/multi/cookies/entertainment/service/IdealWorldCupServiceImpl.java
@@ -1,8 +1,11 @@
+// IdealWorldCupServiceImpl.java
 package com.multi.cookies.entertainment.service;
 
 import com.multi.cookies.entertainment.dao.IdealWorldCupDAO;
 import com.multi.cookies.entertainment.dto.IdealWorldCupDTO;
+import com.multi.cookies.entertainment.dto.InitialSnackListDTO;
 import com.multi.cookies.entertainment.dto.PageDTO;
+import com.multi.cookies.entertainment.service.IdealWorldCupService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -25,17 +28,21 @@ public class IdealWorldCupServiceImpl implements IdealWorldCupService {
     }
 
     @Override
-    public List<String> getAllSnackNames() {
-        return idealWorldCupDAO.list();
-    }
-
-    @Override
-    public void updateWins(String winnerName) {
-        idealWorldCupDAO.updateWins(winnerName);
-    }
-
-    @Override
     public int getSnackCount() {
         return idealWorldCupDAO.count();
+    }
+
+    @Override
+    public void updateWinnerWins(int snack_id) {
+        try {
+            idealWorldCupDAO.updateWins(snack_id);
+        } catch (Exception e) {
+            e.printStackTrace();
+            // 예외 처리
+        }
+    }
+    @Override
+    public List<InitialSnackListDTO> getRandomSnacks(int limit) {
+        return idealWorldCupDAO.getRandomSnacks(limit);
     }
 }

--- a/src/main/resources/mapper/idealBoardMapper.xml
+++ b/src/main/resources/mapper/idealBoardMapper.xml
@@ -2,18 +2,32 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="idealBoard">
 
-    <select id="all" resultType="idealBoardDTO"  parameterType="pageDTO">
+<!--    <select id="all" resultType="idealBoardDTO"  parameterType="pageDTO">-->
+<!--        select * from (-->
+<!--                          select ROW_NUMBER() over(order by ideal_id desc) as idealBoardNum, b.*-->
+<!--                          from ideal_worldcup_bbs b) bbs2-->
+<!--        where bbs2.idealBoardNum between ${start} and ${end}-->
+<!--    </select>-->
+    <select id="all" resultType="idealBoardDTO" parameterType="pageDTO">
         select * from (
-                          select ROW_NUMBER() over(order by ideal_id desc) as idealBoardNum, b.*
-                          from ideal_worldcup_bbs b) bbs2
+        select ROW_NUMBER() over(order by ideal_id desc) as idealBoardNum, b.*
+        from ideal_worldcup_bbs b) bbs2
         where bbs2.idealBoardNum between ${start} and ${end}
+        and bbs2.idealBoardNum between #{start} and #{end} <!-- PageDTO의 start와 end 사용 -->
     </select>
 
+<!--    <select id="list2" resultType="idealBoardDTO" parameterType="pageDTO">-->
+<!--        select * from (-->
+<!--                          select ROW_NUMBER() over(order by ideal_id desc) as idealBoardNum, b.*-->
+<!--                          from ideal_worldcup_bbs b) bbs2-->
+<!--        where bbs2.idealBoardNum between #{start} and #{end}-->
+<!--    </select>-->
     <select id="list2" resultType="idealBoardDTO" parameterType="pageDTO">
         select * from (
-                          select ROW_NUMBER() over(order by ideal_id desc) as idealBoardNum, b.*
-                          from ideal_worldcup_bbs b) bbs2
-        where bbs2.idealBoardNum between #{start} and #{end}
+        select ROW_NUMBER() over(order by ideal_id desc) as idealBoardNum, b.*
+        from ideal_worldcup_bbs b) bbs2
+        where bbs2.idealBoardNum between ${start} and ${end}
+        and bbs2.idealBoardNum between #{start} and #{end} <!-- PageDTO의 start와 end 사용 -->
     </select>
 
     <insert id="insert" parameterType="idealBoardDTO">

--- a/src/main/resources/mapper/idealWorldCupMapper.xml
+++ b/src/main/resources/mapper/idealWorldCupMapper.xml
@@ -6,31 +6,46 @@
         select count(*) from ideal_worldcup
     </select>
 
-    <select id="all" resultType="idealWorldCupDTO"  parameterType="pageDTO">
-        select * from (
-                          select ROW_NUMBER() over(order by ideal_snack_wins desc) as idealRanking, a.*
-                          from ideal_worldcup a) ranking2
-        where ranking2.idealRanking between ${start} and ${end}
+    <select id="all" resultType="idealWorldCupDTO" parameterType="pageDTO">
+        SELECT ranking2.idealRanking, ranking2.snack_id, ranking2.wins, s.snack_name, s.snack_img
+        FROM (
+                 SELECT ROW_NUMBER() OVER(ORDER BY wins DESC) AS idealRanking, snack_id, wins
+                 FROM ideal_worldcup
+             ) ranking2
+                 JOIN snack s ON ranking2.snack_id = s.snack_id
+        WHERE ranking2.idealRanking BETWEEN #{start} AND #{end}
     </select>
 
     <select id="list2" resultType="idealWorldCupDTO" parameterType="pageDTO">
-        select * from (
-                          select ROW_NUMBER() over(order by ideal_snack_wins desc) as idealRanking, a.*
-                          from ideal_worldcup a) ranking2
-        where ranking2.idealRanking between #{start} and #{end}
+        SELECT ranking2.idealRanking, ranking2.snack_id, ranking2.wins, s.snack_name, s.snack_img
+        FROM (
+                 SELECT ROW_NUMBER() OVER(ORDER BY wins DESC) AS idealRanking, snack_id, wins
+                 FROM ideal_worldcup
+             ) ranking2
+                 JOIN snack s ON ranking2.snack_id = s.snack_id
+        WHERE ranking2.idealRanking BETWEEN #{start} AND #{end}
     </select>
 
-    <select id="list" resultType="String">
-        Select ideal_snack_img from ideal_worldcup Order by rand()
-    </select>
+        <update id="updateWinsForSnack" parameterType="int">
+            INSERT INTO ideal_worldcup (snack_id, wins)
+            VALUES (#{snack_id}, 1)
+                ON DUPLICATE KEY UPDATE wins = wins + 1;
+        </update>
 
-<!--    <select id="one" parameterType="String" resultType="idealWorldCupDTO">-->
-<!--        select ideal_snack_img from ideal_worldcup where ideal_snack_name = #{ideal_snack_name}-->
+    <select id="getRandomSnacks" resultType="initialSnackListDTO" parameterType="int">
+        SELECT snack_id, snack_name, snack_img
+        FROM snack
+        ORDER BY RAND() -- MySQL에서 랜덤 순서로 가져오기
+            LIMIT #{limit}
+    </select>
+<!--    <select id="list" resultType="String">-->
+<!--        Select ideal_snack_img from ideal_worldcup Order by rand()-->
 <!--    </select>-->
-    <update id="updateWins" parameterType="String">
-        UPDATE ideal_worldcup
-        SET ideal_snack_wins = ideal_snack_wins + 1
-        WHERE ideal_snack_img = #{winner}
-    </update>
+
+<!--    <update id="updateWins" parameterType="String">-->
+<!--        UPDATE ideal_worldcup-->
+<!--        SET wins = wins + 1-->
+<!--        WHERE snack_id = #{winner}-->
+<!--    </update>-->
 
 </mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -14,6 +14,7 @@
         <typeAlias type="com.multi.cookies.member.dto.MemberDTO" alias="memberDTO"></typeAlias>
         <typeAlias type="com.multi.cookies.entertainment.dto.IdealBoardDTO" alias="idealBoardDTO"></typeAlias>
         <typeAlias type="com.multi.cookies.entertainment.dto.IdealWorldCupDTO" alias="idealWorldCupDTO"></typeAlias>
+        <typeAlias type="com.multi.cookies.entertainment.dto.InitialSnackListDTO" alias="InitialSnackListDTO"></typeAlias>
         <typeAlias type="com.multi.cookies.entertainment.dto.PageDTO" alias="pageDTO"></typeAlias>
         <typeAlias type="com.multi.cookies.board.dto.ReviewDTO" alias="reviewDTO"></typeAlias>
         <typeAlias type="com.multi.cookies.board.dto.BoardDTO" alias="boardDTO"></typeAlias>

--- a/src/main/webapp/WEB-INF/views/entertainment/idealBoardAll.jsp
+++ b/src/main/webapp/WEB-INF/views/entertainment/idealBoardAll.jsp
@@ -8,9 +8,10 @@
            1)글 작성시 닉네임, 비밀번호, 내용 입력안하면 alter 띄우고 insert안되는 기능 (해결)
            2)삭제 버튼 누르면 비밀번호 입력하는 alter띄우기 (해결)
            3)삭제 비밀번호 틀리면 삭제 안되게 하기 (해결)
-           4)이상형월드컵 게임
+           4)이상형월드컵 게임 (해결)
            5)이상형월드컵 랭킹 구현 (해결)
-           5)페이지 합칠지 나눌지 css어떻게할지 정리
+           6)db 유니크 키
+           7)페이지 합칠지 나눌지 css어떻게할지 정리
 
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
@@ -18,6 +19,60 @@
 <html>
 <head>
     <%@ include file="/link.jsp" %>
+    <style>
+        /* 버튼 스타일 적용 */
+        .saveIdealBoard, .deleteIdealBoard, .pages {
+            display: inline-block;
+            padding: 8px 16px;
+            background-color: #B48D69;
+            color: #F9F5F2;
+            border: none;
+            border-radius: 12px;
+            cursor: pointer;
+            transition: background-color 0.3s, color 0.3s;
+        }
+
+        .saveIdealBoard:hover, .deleteIdealBoard:hover, .pages:hover {
+            background-color: #966D48;
+            color: #FFF;
+        }
+
+        /* 입력 필드 스타일 적용 */
+        .input-wrap {
+            background: #E9E2D9;
+            padding: 16px;
+            border-radius: 12px;
+            margin: 20px 0;
+        }
+
+        .input-wrap input {
+            display: block;
+            margin-bottom: 12px;
+            padding: 8px 12px;
+            border: 1px solid #CBB89B;
+            border-radius: 6px;
+            background-color: #FFF;
+            font-size: 14px;
+        }
+
+        /* 페이지 버튼 스타일 적용 */
+        .pages {
+            background: #E9E2D9;
+            color: #5C492C;
+            width: 50px;
+            padding: 8px;
+            margin-right: 4px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: background-color 0.3s, color 0.3s;
+        }
+
+        .pages:hover {
+            background-color: #CBB89B;
+            color: #452C07;
+        }
+    </style>
     <script type="text/javascript">
 
         $(function() {
@@ -96,7 +151,7 @@
                         page : $(this).text()
                     },
                     success : function(result) { //결과가 담겨진 table부분코드
-                         $('#d1').html(result)
+                        $('#d1').html(result)
 
                     },
                     error : function() {
@@ -129,7 +184,7 @@
                 <td class="right">${one.ideal_id}</td> <!-- one.getId() -->
                 <td class="right">${one.ideal_nickname}</td>
                 <td class="right">${one.ideal_content}</td>
-                <td class="right"><fmt:formatDate value="${one.create_dt}" pattern="yyyy-MM-dd hh:mm:ss"/></td>
+                <td class="right"><fmt:formatDate value="${one.create_dt}" pattern="yyyy-MM-dd HH:mm:ss"/></td>
                 <td class="right">
                     <button  class="deleteIdealBoard" value="${one.ideal_id}" style="background: #E9E2D9; color: #5C492C; width: 50px;">삭제</button>
                 </td>

--- a/src/main/webapp/WEB-INF/views/entertainment/idealBoardList.jsp
+++ b/src/main/webapp/WEB-INF/views/entertainment/idealBoardList.jsp
@@ -43,17 +43,17 @@
 </script>
 <table>
   <tr>
-    <td class="left">글 번호</td>
+<%--    <td class="left">글 번호</td>--%>
     <td class="left">닉네임</td>
     <td class="left">내용</td>
     <td class="left">작성시간</td>
   </tr>
   <c:forEach items="${list}" var="one">
     <tr>
-      <td class="right">${one.ideal_id}</td> <!-- one.getId() -->
+<%--      <td class="right">${one.ideal_id}</td> <!-- one.getId() -->--%>
       <td class="right">${one.ideal_nickname}</td>
       <td class="right">${one.ideal_content}</td>
-      <td class="right"><fmt:formatDate value="${one.create_dt}" pattern="yyyy-MM-dd hh:mm:ss"/></td>
+      <td class="right"><fmt:formatDate value="${one.create_dt}" pattern="yyyy-MM-dd HH:mm:ss"/></td>
       <td class="right">
         <button  class="deleteIdealBoard" value="${one.ideal_id}" style="background: #E9E2D9; color: #5C492C; width: 50px;">삭제</button>
       </td>

--- a/src/main/webapp/WEB-INF/views/entertainment/idealWorldCupAll.jsp
+++ b/src/main/webapp/WEB-INF/views/entertainment/idealWorldCupAll.jsp
@@ -44,8 +44,8 @@
         <c:forEach items="${list}" var="one">
             <tr>
                 <td class="right">${one.idealRanking}</td> <!-- one.getId() -->
-                <td class="right"><img src = "/resources/img/entertainment/${one.ideal_snack_img}" width="200" height="200"></td>
-                <td class="right">${one.ideal_snack_name}</td>
+                <td class="right"><img src = "${one.snack_img}" width="300" height="200"></td>
+                <td class="right">${one.snack_name}</td>
             </tr>
         </c:forEach>
     </table>

--- a/src/main/webapp/WEB-INF/views/entertainment/idealWorldCupGame.jsp
+++ b/src/main/webapp/WEB-INF/views/entertainment/idealWorldCupGame.jsp
@@ -4,9 +4,8 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <div id="d1">
     <%
-        //몇강인지 선택 받아와서 kang에 Integer로 저장
         String selectedRound = request.getParameter("kang");
-        int kang = Integer.parseInt(selectedRound);
+        int round = Integer.parseInt(selectedRound)/2;
     %>
 </div>
 <head>
@@ -32,101 +31,122 @@
             max-height: 100%;
         }
     </style>
+    <script>
+        var kangValue = ${param.kang};
+    </script>
 </head>
 <body>
 <%@include file="/header.jsp" %>
+<p>${param.kang}강</p>
+<p><span id="match">1</span>/<span id="round"><%=round%></span></p>
+
 <div id="buttonsContainer">
-    <button class="img-button" data-image="" id="button0">
+    <button class="img-button" data-image="" data-id="" data-name="" id="button0">
         <div>
-            <img src="/resources/img/entertainment/image1.jpg" alt="">
-            <span></span>
+            <img src="" alt="">
         </div>
+        <span></span>
     </button>
-    <button class="img-button" data-image="" id="button1">
+    <button class="img-button" data-image="" data-id="" data-name="" id="button1">
         <div>
-            <img src="/resources/img/entertainment/image2.jpg" alt="">
-            <span></span>
+            <img src="" alt="">
         </div>
+        <span></span>
     </button>
 </div>
 <script>
-    var SnackList = [
-        <c:forEach items="${list}" var="image" varStatus="loop">
-        "${image}"<c:if test="${not loop.last}">,</c:if>
+    var round = <%=round%>; // JSP에서 변수의 값을 JavaScript로 전달
+    var matchElement = document.getElementById('match');
+    var roundElement = document.getElementById('round');
+    var nextSnackList = [
+        <c:forEach items="${randomSnacks}" var="snack" varStatus="loop">
+        {
+            snack_id: "${snack.snack_id}",
+            snack_name: "${snack.snack_name}",
+            snack_img: "${snack.snack_img}"
+        }<c:if test="${not loop.last}">,</c:if>
         </c:forEach>
     ];
-    var kangValue = <%= kang %>;
-    var initialSnackList = SnackList.slice(0, kangValue); // 처음 랜덤으로 받아온 N개의 스넥을 몇강인지에따라 맞춰서 초기화
-    var nextSnackList= initialSnackList; //과자 리스트에 처음 초기화 값은 몇강인지에 따라
-    console.log(initialSnackList)
 
-    var index0 = 0; //왼쪽 버튼의 인덱스
-    var index1 = 1; //오른쪽 버튼의 인덱스
+    var index0 = 0;
+    var index1 = 1;
     var buttons = document.querySelectorAll('.img-button');
-    var winsImages = []; //이기면 저장되는 배열
-    var clickCnt = 0; //클릭횟수
-    var winner =[];
+    var winnerList = [];
+    var clickCnt = 0;
+    var match = 1;
+    var round = kangValue / 2;
+    var champion = [];
 
-    function updateButton(buttonIndex, imageIndex) { //버튼 0 (왼쪽)과 1 (오른쪽)에 이미지 배열 인덱스 번호 넣는 함수
-        //nextSnackList에서 가져온다.
-        buttons[buttonIndex].setAttribute('data-image', nextSnackList[imageIndex]); //배열에서 가져와서 해당 버튼의 data-image 속성에 설정하는 역할
-        buttons[buttonIndex].querySelector('img').src = '/resources/img/entertainment/' + nextSnackList[imageIndex]; //이미지 경로 설정 배열에 인덱스
-
-        //.jpg 제거 하는 부분
-        var imageFileName = nextSnackList[imageIndex];
-        var imageNameWithoutExtension = imageFileName.replace('.jpg', '');
-        buttons[buttonIndex].querySelector('span').textContent = imageNameWithoutExtension;
-
+    function updateButton(buttonIndex, imageIndex) {
+        buttons[buttonIndex].setAttribute('data-image', nextSnackList[imageIndex].snack_img);
+        buttons[buttonIndex].setAttribute('data-id', nextSnackList[imageIndex].snack_id);
+        buttons[buttonIndex].setAttribute('data-name', nextSnackList[imageIndex].snack_name);
+        buttons[buttonIndex].querySelector('img').src = nextSnackList[imageIndex].snack_img;
+        buttons[buttonIndex].querySelector('span').textContent = nextSnackList[imageIndex].snack_name;
     }
 
-    buttons.forEach(function(button, buttonIndex) { // 클릭시 발생하는 함수 (1.인덱스 +1) (2.새로운 배열에 클릭한 사진 넣기)
-        button.addEventListener('click', function() {
-            var href;
+    buttons.forEach(function (button, buttonIndex) {
+        button.addEventListener('click', function () {
             if (kangValue == 2) {
                 var image = this.getAttribute('data-image');
-                winner.push(image);
-                console.log("winner ", winner)
-                //location.href = 'idealWorldCupGameOverAll.jsp?winner='+winner
-                location.replace('idealWorldCupGameOverAll.jsp?winner='+winner)
+                var snack_id = this.getAttribute('data-id');
+                var snack_name = this.getAttribute('data-name');
+                champion.push({ snack_id, snack_name, snack_img: image });
+
+                var encodedChampion = encodeURIComponent(JSON.stringify(champion)); // URL 안전한 형태로 인코딩
+
+                location.replace('idealWorldCupGameOverAll.jsp?champion=' + encodedChampion);
             }
             clickCnt++;
-            if(clickCnt==(kangValue/2)) {
+            match++; // 매치 번호 업데이트
+            if (clickCnt == (kangValue / 2)) {
                 kangValue = clickCnt;
                 clickCnt = 0;
-                winsImages = winsImages.sort(() => Math.random() - 0.5);
-                nextSnackList = winsImages;
+                match = 1;
+                round= round/2;
+                winnerList = winnerList.sort(() => Math.random() - 0.5);
+                nextSnackList = winnerList;
                 nextSnackList = nextSnackList.sort(() => Math.random() - 0.5);
-                // console.log("1차끝", "nextSnackList =", nextSnackList, "winsImages =", winsImages)
+                // console.log("1차끝", "nextSnackList =", nextSnackList, "winnerList =", winnerList)
 
                 var image = this.getAttribute('data-image');
-                winsImages.push(image);
-                winsImages = [];
+                var snack_id = this.getAttribute('data-id');
+                var snack_name = this.getAttribute('data-name');
+                winnerList.push({ snack_id, snack_name, snack_img: image });
+                winnerList = [];
                 index0 = (index0 + 2) % nextSnackList.length;
                 updateButton(0, index0);
                 index1 = (index1 + 2) % nextSnackList.length;
                 updateButton(1, index1);
+
                 // console.log("여긴(clickCnt==(kangValue/2))")
                 // console.log("nextSnackList ", nextSnackList);
-                // console.log("winsImages ", winsImages);
-                // console.log("winsImages length ", winsImages.length);
+                // console.log("winnerList ", winnerList);
+                // console.log("winnerList length ", winnerList.length);
+                // console.log("kangValue", kangValue);
+                // console.log("clickCnt ", clickCnt);
+
+            } else {
+
+                var image = this.getAttribute('data-image');
+                var snack_id = this.getAttribute('data-id');
+                var snack_name = this.getAttribute('data-name');
+                winnerList.push({ snack_id, snack_name, snack_img: image });
+                index0 = (index0 + 2) % nextSnackList.length;
+                updateButton(0, index0);
+                index1 = (index1 + 2) % nextSnackList.length;
+                updateButton(1, index1);
+                // console.log("여긴else");
+                // console.log("nextSnackList ", nextSnackList);
+                // console.log("winnerList ", winnerList);
+                // console.log("winnerList length ", winnerList.length);
                 // console.log("kangValue", kangValue);
                 // console.log("clickCnt ", clickCnt);
             }
-            else{
-                    var image = this.getAttribute('data-image');
-                    winsImages.push(image);
-                    index0 = (index0 + 2) % nextSnackList.length;
-                    updateButton(0, index0);
-                    index1 = (index1 + 2) % nextSnackList.length;
-                    updateButton(1, index1);
-                    // console.log("nextSnackList ",nextSnackList);
-                    // console.log("winsImages ",winsImages);
-                    // console.log("winsImages length ",winsImages.length);
-                    // console.log("kangValue", kangValue);
-                    // console.log("clickCnt ",clickCnt);
-            }
+            // match와 round 값 업데이트
+            matchElement.textContent = match;
+            roundElement.textContent = round;
         });
-        //updateButton(buttonIndex);
         updateButton(0, index0);
         updateButton(1, index1);
     });

--- a/src/main/webapp/WEB-INF/views/entertainment/idealWorldCupList.jsp
+++ b/src/main/webapp/WEB-INF/views/entertainment/idealWorldCupList.jsp
@@ -17,8 +17,8 @@
     <c:forEach items="${list}" var="one">
       <tr>
         <td class="right">${one.idealRanking}</td> <!-- one.getId() -->
-        <td class="right"><img src = "/resources/img/entertainment/${one.ideal_snack_img}" width="200" height="200"></td>
-        <td class="right">${one.ideal_snack_name}</td>
+        <td class="right"><img src = "${one.snack_img}" width="300" height="200"></td>
+        <td class="right">${one.snack_name}</td>
       </tr>
     </c:forEach>
   </table>

--- a/src/main/webapp/entertainment/ideal.jsp
+++ b/src/main/webapp/entertainment/ideal.jsp
@@ -19,11 +19,15 @@
         <form action="/entertainment/idealWorldCupGame" method="get">
             <label for="kang">라운드를 선택 해주세요:</label>
             <select name="kang" id="kang">
+                <option value="4">4강</option>
                 <option value="8">8강</option>
-                <option value="4" selected>4강</option>
+                <option value="16">16강</option>
+                <option value="32">32강</option>
+                <option value="64">64강</option>
+                <option value="128">128강</option>
             </select>
             <br><br>
-            <input type="submit" value="시작하기" style="background: #5C492C; color: black; width: 70px;">
+            <input type="submit" value="시작하기" style="background: #5C492C; color: black; width: 70px;" onclick="resetSessionStorage()">
         </form>
     </tr>
     <tr>
@@ -43,5 +47,12 @@
     </tr>
 </table>
 <%@include file="../footer.jsp" %>
+<script>
+    // 시작하기 버튼을 누르면 세션 스토리지 초기화
+    function resetSessionStorage() {
+        sessionStorage.removeItem('champion');
+        sessionStorage.removeItem('updated');
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
이상형월드컵 게임기능 마무리 css만 손보면 될듯함

- 기존 db말고 snack db를 이용하는걸로 수정

- 기존에 없던 게임 세부 기능들 추가

1. 128강까지 구현 / 수정시 snack db 개수만큼 가능 (select box 추가만하면)
2. 게임 승리시 db에 승리 +1(세션으로 중복막음)

- 새로운 dto 추가 (snack db에서 가져와서 리스트만들때 사용)
